### PR TITLE
function sign bug fixed

### DIFF
--- a/python/ccxt/cointiger.py
+++ b/python/ccxt/cointiger.py
@@ -534,7 +534,7 @@ class cointiger (huobipro):
             keys = list(query.keys())
             auth = ''
             for i in range(0, len(keys)):
-                auth += keys[i] + query[keys[i]]
+                auth += keys[i] + str(query[keys[i]])
             auth += self.secret
             signature = self.hmac(self.encode(auth), self.encode(self.secret), hashlib.sha512)
             isCreateOrderMethod = (path == 'order') and(method == 'POST')


### PR DESCRIPTION
  File "C:\ProgramData\Anaconda3\lib\site-packages\ccxt\cointiger.py", line 537, in sign
    auth += keys[i] + query[keys[i]]
TypeError: must be str, not int

replace by:
    auth += keys[i] + str(query[keys[i]])